### PR TITLE
Fix edge case in TCPClient findDelimiter

### DIFF
--- a/addons/ofxNetwork/src/ofxTCPClient.cpp
+++ b/addons/ofxNetwork/src/ofxTCPClient.cpp
@@ -283,6 +283,10 @@ static int findDelimiter(char * data, int size, string delimiter){
 			posInDelimiter++;
 			if(posInDelimiter==delimiter.size()) return i-delimiter.size()+1;
 		}else{
+			if(posInDelimiter>0){
+				// Stay at the same position to try matching again
+				i--;
+			}
 			posInDelimiter=0;
 		}
 	}


### PR DESCRIPTION
Fix for a failure to find the TCP delimiter when the incoming stream repeats the first character of delimiter sequence. Before this fix, a stream like `...[[/TCP]...` fails because the matcher doesn't reset after the first `[` is identified.